### PR TITLE
feat/useContext: add example for useContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import UseCallback from "./pages/UseCallback";
 import UseMemo from "./pages/UseMemo";
+import UseContext from "./pages/UseContext";
 
 function App() {
     return (
@@ -18,6 +19,7 @@ function App() {
                     <Route path="useeffect" element={<UseEffect />} />
                     <Route path="usecallback" element={<UseCallback />} />
                     <Route path="usememo" element={<UseMemo />} />
+                    <Route path="usecontext" element={<UseContext />} />
                 </Routes>
                 <Footer />
             </div>

--- a/src/components/examples/useContext/Overview.tsx
+++ b/src/components/examples/useContext/Overview.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+const basicSyntax = `// Create a context
+const MyContext = React.createContext(defaultValue);
+
+// Provide the context
+<MyContext.Provider value={value}>
+    {/* children */}
+</MyContext.Provider>
+
+// Consume the context
+const value = useContext(MyContext);`;
+
+const themeExample = `// Create a theme context
+const ThemeContext = React.createContext('light');
+
+// Provide the theme
+<ThemeContext.Provider value="dark">
+    <App />
+</ThemeContext.Provider>
+
+// Use the theme
+const theme = useContext(ThemeContext);`;
+
+const userExample = `// Create a user context
+const UserContext = React.createContext(null);
+
+// Provide user data
+<UserContext.Provider value={{ name: 'John', age: 30 }}>
+    <Profile />
+</UserContext.Provider>
+
+// Use user data
+const user = useContext(UserContext);`;
+
+const Overview: React.FC = () => {
+    return (
+        <section id="overview" className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Overview</h2>
+            <div className="space-y-4">
+                <p className="text-gray-600">
+                    The <code className="bg-gray-100 px-1 py-0.5 rounded">useContext</code> hook is used to consume values from a React context. It allows you to access context values without having to pass props through every level of the component tree.
+                </p>
+                <div className="bg-gray-50 border rounded-lg p-4">
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">Basic Syntax</h3>
+                    <pre className="bg-gray-50 border rounded-lg p-4 overflow-x-auto">
+                        <code className="text-sm">{basicSyntax}</code>
+                    </pre>
+                </div>
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                    <h3 className="text-lg font-medium text-blue-900 mb-2">Key Points</h3>
+                    <ul className="list-disc list-inside space-y-2 text-blue-800">
+                        <li>Provides a way to share data between components without prop drilling</li>
+                        <li>Context values can be updated and all consuming components will re-render</li>
+                        <li>Can be used for global state management in smaller applications</li>
+                        <li>Works well with other hooks like useState and useReducer</li>
+                    </ul>
+                </div>
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                    <h3 className="text-lg font-medium text-green-900 mb-2">Common Usage Examples</h3>
+                    <div className="space-y-4">
+                        <div>
+                            <h4 className="font-medium text-green-800 mb-2">Theme Context</h4>
+                            <pre className="bg-white border rounded-lg p-3 overflow-x-auto">
+                                <code className="text-sm">{themeExample}</code>
+                            </pre>
+                        </div>
+                        <div>
+                            <h4 className="font-medium text-green-800 mb-2">User Context</h4>
+                            <pre className="bg-white border rounded-lg p-3 overflow-x-auto">
+                                <code className="text-sm">{userExample}</code>
+                            </pre>
+                        </div>
+                    </div>
+                </div>
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                    <h3 className="text-lg font-medium text-yellow-900 mb-2">⚠️ Important Considerations</h3>
+                    <ul className="list-disc list-inside space-y-2 text-yellow-800">
+                        <li>Context should be used for data that needs to be accessed by many components at different nesting levels</li>
+                        <li>Don't use context for data that only needs to be passed down a few levels - props are better for that</li>
+                        <li>Be mindful of performance - context changes will cause all consuming components to re-render</li>
+                        <li>Consider splitting contexts to prevent unnecessary re-renders</li>
+                        <li>For complex state management, consider using a state management library like Redux or Zustand</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Overview;

--- a/src/components/examples/useContext/ThemeExample.tsx
+++ b/src/components/examples/useContext/ThemeExample.tsx
@@ -1,0 +1,108 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const codeExample = `import React, { createContext, useContext, useState } from 'react';
+
+// Create a theme context
+const ThemeContext = createContext({
+    theme: 'light',
+    toggleTheme: () => {},
+});
+
+// Theme provider component
+const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [theme, setTheme] = useState('light');
+
+    const toggleTheme = () => {
+        setTheme(prev => prev === 'light' ? 'dark' : 'light');
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+};
+
+// Component using the theme
+const ThemedComponent: React.FC = () => {
+    const { theme, toggleTheme } = useContext(ThemeContext);
+
+    return (
+        <div className={\`p-4 \${theme === 'dark' ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}\`}>
+            <p>Current theme: {theme}</p>
+            <button onClick={toggleTheme}>Toggle Theme</button>
+        </div>
+    );
+};`;
+
+// Create a theme context
+const ThemeContext = createContext<{
+    theme: string;
+    toggleTheme: () => void;
+}>({
+    theme: 'light',
+    toggleTheme: () => { },
+});
+
+// Theme provider component
+const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [theme, setTheme] = useState('light');
+
+    const toggleTheme = () => {
+        setTheme(prev => prev === 'light' ? 'dark' : 'light');
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+};
+
+// Component using the theme
+const ThemedComponent: React.FC = () => {
+    const { theme, toggleTheme } = useContext(ThemeContext);
+
+    return (
+        <div className={`p-4 ${theme === 'dark' ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}>
+            <p>Current theme: {theme}</p>
+            <button
+                onClick={toggleTheme}
+                className="mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+            >
+                Toggle Theme
+            </button>
+        </div>
+    );
+};
+
+const ThemeExample: React.FC = () => {
+    return (
+        <section id="theme-example" className="mb-12">
+            <h2 className="text-2xl font-bold mb-4">Theme Context Example</h2>
+            <p className="mb-4">
+                This example demonstrates how useContext can be used to manage a theme across multiple components without prop drilling.
+            </p>
+            <ul className="list-disc pl-6 mb-4">
+                <li>The theme state is managed in a context provider</li>
+                <li>Components can access and modify the theme without receiving props</li>
+                <li>The theme change affects all components using the context</li>
+            </ul>
+
+            {/* Code Syntax */}
+            <pre className="bg-gray-50 border rounded-lg p-4 overflow-x-auto">
+                <code className="text-sm">{codeExample}</code>
+            </pre>
+
+            {/* Live Demo */}
+            <div className="mt-6 p-6 bg-white border rounded-lg">
+                <h3 className="text-lg font-medium text-gray-900 mb-4">Live Demo</h3>
+                <ThemeProvider>
+                    <ThemedComponent />
+                </ThemeProvider>
+            </div>
+        </section>
+    );
+};
+
+export default ThemeExample;

--- a/src/pages/UseContext.tsx
+++ b/src/pages/UseContext.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import ExampleHeader from "../components/ExampleHeader";
+import ExampleSidebar from "../components/ExampleSidebar";
+import Overview from "../components/examples/useContext/Overview";
+import ThemeExample from "@/components/examples/useContext/ThemeExample";
+
+const UseContext: React.FC = () => {
+    const sidebarSections = [
+        { id: "overview", title: "Overview" },
+        { id: "theme-example", title: "Theme Example" },
+    ];
+
+    return (
+        <div className="min-h-screen bg-white">
+            <ExampleHeader
+                title="useContext Examples"
+                description="Explore various examples demonstrating the use of the useContext hook in React."
+            />
+            {/* Main Content with Sidebar */}
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <div className="flex flex-col lg:flex-row lg:space-x-8">
+                    {/* Main Content */}
+                    <main className="flex-1">
+                        <div className="prose max-w-none">
+                            <Overview />
+                            <ThemeExample />
+                        </div>
+                    </main>
+
+                    {/* Right Sidebar Navigation */}
+                    <ExampleSidebar sections={sidebarSections} />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UseContext;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new page demonstrating the use of React's `useContext` hook, accessible via the app's navigation.
  - Added an overview section explaining `useContext` with practical examples and key considerations.
  - Included an interactive theme switching example to illustrate context usage in real-time.
  - Enhanced navigation with a sidebar for quick access to examples and overviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->